### PR TITLE
Mute fix

### DIFF
--- a/Sources/Hoa_MultiEncoder.hpp
+++ b/Sources/Hoa_MultiEncoder.hpp
@@ -172,6 +172,11 @@ namespace hoa
             
             for(size_t i = 1; i < nencoders; i++)
             {
+                if(m_encoders[i].getMute())
+                {
+                    continue;
+                }
+
                 m_encoders[i].process(++input, m_temp);
                 sigadd(nharmos, m_temp, outputs);
             }


### PR DESCRIPTION
When doing source mute on **MultiEncoder2d** found an error:

when you mute source 0 everything is ok, but when you mute other sources, they are not muted but continue to produce fixed signal. This problem was found on PureData, because it place input and output buffers in the same memory.

This pull request solves this problem by not only skipping processing of muted sources, but also not adding it's output to main output
